### PR TITLE
Python 2.x doesn't accept keyword arguments for builtins

### DIFF
--- a/py2neo/server.py
+++ b/py2neo/server.py
@@ -189,7 +189,7 @@ class GraphServer(object):
         else:
             uri = None
             kwargs = {}
-            for line in out.decode("utf-8").splitlines(keepends=False):
+            for line in out.decode("utf-8").splitlines(False):
                 if line.startswith("Using additional JVM arguments:"):
                     kwargs["jvm_arguments"] = shlex.split(line[32:])
                 elif line.startswith("process"):
@@ -231,7 +231,7 @@ class GraphServer(object):
                               "server status [%s]" % error.returncode)
         else:
             p = None
-            for line in out.decode("utf-8").splitlines(keepends=False):
+            for line in out.decode("utf-8").splitlines(False):
                 if "running" in line:
                     p = int(line.rpartition(" ")[-1])
             return p
@@ -250,7 +250,7 @@ class GraphServer(object):
                               "server info [%s]" % error.returncode)
         else:
             data = {}
-            for line in out.decode("utf-8").splitlines(keepends=False):
+            for line in out.decode("utf-8").splitlines(False):
                 try:
                     colon = line.index(":")
                 except ValueError:


### PR DESCRIPTION
Sorry, I couldn't find a better reference but see similar issue: http://stackoverflow.com/questions/27493703/typeerror-split-takes-no-keyword-arguments