### PR TITLE
bugfix: updating the cached properties with fetched properties

### DIFF
--- a/py2neo/core.py
+++ b/py2neo/core.py
@@ -1428,8 +1428,8 @@ class Node(PropertyContainer):
         if "data" in data:
             inst.__stale.discard("properties")
             properties = data["data"]
-            properties.update(inst.properties)
-            inst._PropertyContainer__properties.replace(properties)
+            inst.properties.update(properties)
+
         if "metadata" in data:
             inst.__stale.discard("labels")
             metadata = data["metadata"]


### PR DESCRIPTION
Bugfix for #427.
Was previously updating the fetched properties with the cached ones, which meant the cached (i.e. old/out of date values) were used.

*Note:* I am unable to run unittests with a fresh py2neo checkout - see #426. You should verify the test suite passes before merging.

@nigelsmall 