### PR TITLE
Set attributes of RecordList before calling logger in __init__

### DIFF
--- a/py2neo/cypher/core.py
+++ b/py2neo/cypher/core.py
@@ -370,9 +370,9 @@ class RecordList(object):
         return cls(columns, [producer.produce(graph.hydrate(row)) for row in rows])
 
     def __init__(self, columns, records):
-        log.info("result %r %r", columns, len(records))
         self.columns = columns
         self.records = records
+        log.info("result %r %r", columns, len(records))
 
     def __repr__(self):
         out = ""


### PR DESCRIPTION
Raven (a logger) for example calls __repr__, which needs an initialized self.columns => exception is raised