### PR TITLE
Cursor.dump: fixed TypeError while formatting output

### DIFF
--- a/py2neo/database/__init__.py
+++ b/py2neo/database/__init__.py
@@ -1378,7 +1378,7 @@ class Cursor(object):
         out.write(u"".join("-" * (width + 2) for width in widths))
         out.write(u"\n")
         for i, record in enumerate(records):
-            out.write(u"".join(templates[i].format(value) for i, value in enumerate(record)))
+            out.write(u"".join(templates[i].format(ustr(value)) for i, value in enumerate(record)))
             out.write(u"\n")
 
 


### PR DESCRIPTION
The output values are now explicitly converted to ustr before output. This
prevents a TypeError [1] if e.g. a Node object is printed to the output.

[1] TypeError: non-empty format string passed to object.__format__