### PR TITLE
Fixed overzealous relationship deletion

### DIFF
--- a/py2neo/database/__init__.py
+++ b/py2neo/database/__init__.py
@@ -389,14 +389,16 @@ class Graph(object):
         """
         return self.begin(autocommit=True).degree(subgraph)
 
-    def delete(self, subgraph):
+    def delete(self, subgraph, rels_only=False):
         """ Run a :meth:`.Transaction.delete` operation within an
         `autocommit` :class:`.Transaction`.
 
         :param subgraph: a :class:`.Node`, :class:`.Relationship` or other
                        :class:`.Subgraph` object
+        :param rels_only: a flag indicating if only the relationships
+                          in the subgraph should be deleted
         """
-        self.begin(autocommit=True).delete(subgraph)
+        self.begin(autocommit=True).delete(subgraph, rels_only=rels_only)
 
     def delete_all(self):
         """ Delete all nodes and relationships from the graph.
@@ -1058,15 +1060,17 @@ class Transaction(object):
         except AttributeError:
             raise TypeError("No method defined to determine the degree of object %r" % subgraph)
 
-    def delete(self, subgraph):
+    def delete(self, subgraph, rels_only=False):
         """ Delete the remote nodes and relationships that correspond to
         those in a local subgraph.
 
         :param subgraph: a :class:`.Node`, :class:`.Relationship` or other
                        :class:`.Subgraph`
+        :param rels_only: a flag indicating if only the relationships
+                          in the subgraph should be deleted
         """
         try:
-            subgraph.__db_delete__(self)
+            subgraph.__db_delete__(self, rels_only=rels_only)
         except AttributeError:
             raise TypeError("No method defined to delete object %r" % subgraph)
 

--- a/py2neo/types.py
+++ b/py2neo/types.py
@@ -336,7 +336,7 @@ class Subgraph(object):
         parameters = {"x": node_ids}
         return tx.evaluate(statement, parameters)
 
-    def __db_delete__(self, tx):
+    def __db_delete__(self, tx, rels_only=False):
         matches = []
         deletes = []
         parameters = {}
@@ -350,16 +350,17 @@ class Subgraph(object):
                 deletes.append("DELETE %s" % rel_id)
                 parameters[param_id] = remote_relationship._id
                 del relationship.__remote__
-        for i, node in enumerate(self.nodes()):
-            remote_node = remote(node)
-            if remote_node:
-                node_id = "a%d" % i
-                param_id = "x%d" % i
-                matches.append("MATCH (%s) "
-                               "WHERE id(%s)={%s}" % (node_id, node_id, param_id))
-                deletes.append("DELETE %s" % node_id)
-                parameters[param_id] = remote_node._id
-                del node.__remote__
+        if not rels_only:
+            for i, node in enumerate(self.nodes()):
+                remote_node = remote(node)
+                if remote_node:
+                    node_id = "a%d" % i
+                    param_id = "x%d" % i
+                    matches.append("MATCH (%s) "
+                                   "WHERE id(%s)={%s}" % (node_id, node_id, param_id))
+                    deletes.append("DELETE %s" % node_id)
+                    parameters[param_id] = remote_node._id
+                    del node.__remote__
         statement = "\n".join(matches + deletes)
         tx.run(statement, parameters)
 


### PR DESCRIPTION
Relates to issue #508 

  Because relationships are themselves a walkable subgraph containing
  the start_node, end_node and the relationship itself, calling delete
  on a relationship causes the start_node and end_node to also be
  deleted

  A hacky solution was to add a rels_only keyword argument to the delete
  methods specifying that only the relationships in a subgraph should be
  deleted. Activating this flag when deleting a relationship allows the
  start_node and end_node to remain after the operation