### PR TITLE
Allowed non-qunique relationships to be created

### DIFF
--- a/py2neo/database/__init__.py
+++ b/py2neo/database/__init__.py
@@ -355,14 +355,16 @@ class Graph(object):
         """
         return self.transaction_class(self, autocommit)
 
-    def create(self, subgraph):
+    def create(self, subgraph, unique_rels=True):
         """ Run a :meth:`.Transaction.create` operation within an
         `autocommit` :class:`.Transaction`.
 
         :param subgraph: a :class:`.Node`, :class:`.Relationship` or other
                        :class:`.Subgraph`
+        :param unique_rels: a flag indicating if relationshipos created
+                            between nodes should be unique
         """
-        self.begin(autocommit=True).create(subgraph)
+        self.begin(autocommit=True).create(subgraph, unique_rels=unique_rels)
 
     def create_unique(self, walkable):
         """ Run a :meth:`.Transaction.create_unique` operation within
@@ -1003,7 +1005,7 @@ class Transaction(object):
         """
         return self.run(statement, parameters, **kwparameters).evaluate(0)
 
-    def create(self, subgraph):
+    def create(self, subgraph, unique_rels=True):
         """ Create remote nodes and relationships that correspond to those in a
         local subgraph. Any entities in *subgraph* that are already bound to
         remote entities will remain unchanged, those which are not will become
@@ -1027,7 +1029,7 @@ class Transaction(object):
                     creatable object
         """
         try:
-            subgraph.__db_create__(self)
+            subgraph.__db_create__(self, unique_rels=unique_rels)
         except AttributeError:
             raise TypeError("No method defined to create object %r" % subgraph)
 

--- a/py2neo/types.py
+++ b/py2neo/types.py
@@ -289,7 +289,7 @@ class Subgraph(object):
         n = (nodes(self) ^ nodes(other)) | set().union(*(nodes(rel) for rel in r))
         return Subgraph(n, r)
 
-    def __db_create__(self, tx):
+    def __db_create__(self, tx, unique_rels=True):
         from py2neo.database.cypher import cypher_escape
         nodes = list(self.nodes())
         reads = []
@@ -317,8 +317,10 @@ class Subgraph(object):
                 end_node_id = "a%d" % nodes.index(relationship.end_node())
                 type_string = cypher_escape(relationship.type())
                 param_id = "y%d" % i
-                writes.append("CREATE UNIQUE (%s)-[%s:%s]->(%s) SET %s={%s}" %
-                              (start_node_id, rel_id, type_string, end_node_id, rel_id, param_id))
+                unique_str = 'UNIQUE ' if unique_rels else ''
+                writes.append("CREATE %s(%s)-[%s:%s]->(%s) SET %s={%s}" %
+                              (unique_str, start_node_id, rel_id, type_string, end_node_id, rel_id,
+                               param_id))
                 parameters[param_id] = dict(relationship)
                 returns[rel_id] = relationship
                 relationship._set_remote_pending(tx)


### PR DESCRIPTION
Relates to issue #507 

  By adding a flag to the various create() methods, I was able to allow
  non-unique relationships to be created in a subgraph. By default, this
  is disabled, so py2neo should funcition as before. This simply allows
  the user to specify that more than one relationship of a specific type
  may be created between two nodes.