### PR TITLE
Support lists (or collections) for Node's name property

### DIFF
--- a/py2neo/util.py
+++ b/py2neo/util.py
@@ -33,11 +33,10 @@ WORD_ALL = re.compile("([a-z0-9])([A-Z])")
 
 
 def snake_case(s):
-    if isinstance(s, list) or isinstance(s, tuple) or isinstance(s, set):
+    if is_collection(s):
         s = "_".join(s)
 
     words = s.replace("_", " ").replace("-", " ").split()
-
     return "_".join(word.lower() for word in words)
 
 

--- a/py2neo/util.py
+++ b/py2neo/util.py
@@ -33,7 +33,11 @@ WORD_ALL = re.compile("([a-z0-9])([A-Z])")
 
 
 def snake_case(s):
+    if isinstance(s, list) or isinstance(s, tuple) or isinstance(s, set):
+        s = "_".join(s)
+
     words = s.replace("_", " ").replace("-", " ").split()
+
     return "_".join(word.lower() for word in words)
 
 

--- a/test/test_entity.py
+++ b/test/test_entity.py
@@ -78,10 +78,6 @@ class AutoNamingTestCase(GraphTestCase):
         a = Node(name=("Alice", "爱丽丝"))
         assert a.__name__ == "alice_爱丽丝"
 
-    def test_can_name_using_set_as_name_property(self):
-        a = Node(name=set(["Alice", "Alicia"]))
-        assert a.__name__ == "alicia_alice"
-
     def test_can_name_using_magic_name_property(self):
         a = Node(__name__="Alice")
         assert a.__name__ == "Alice"

--- a/test/test_entity.py
+++ b/test/test_entity.py
@@ -21,7 +21,7 @@ from test.util import GraphTestCase
 
 
 class EntityTestCase(GraphTestCase):
-        
+
     def test_can_create_entity_with_initial_uri(self):
         uri = "http://localhost:7474/db/data/node/1"
         entity = Node()
@@ -69,6 +69,18 @@ class AutoNamingTestCase(GraphTestCase):
     def test_can_name_using_name_property(self):
         a = Node(name="Alice")
         assert a.__name__ == "alice"
+
+    def test_can_name_using_list_as_name_property(self):
+        a = Node(name=["Alice", "爱丽丝"])
+        assert a.__name__ == "alice_爱丽丝"
+
+    def test_can_name_using_tuple_as_name_property(self):
+        a = Node(name=("Alice", "爱丽丝"))
+        assert a.__name__ == "alice_爱丽丝"
+
+    def test_can_name_using_set_as_name_property(self):
+        a = Node(name=set(["Alice", "Alicia"]))
+        assert a.__name__ == "alicia_alice"
 
     def test_can_name_using_magic_name_property(self):
         a = Node(__name__="Alice")


### PR DESCRIPTION
A person may have more than one name. For instance an English and a Chinese name. As such a person, represented as a Node type may have name property represented as a list.

Implement functionality to ensure lists, tuples and sets are supported for Node's name property.